### PR TITLE
Lisätään tietosuojaseloste tekniikan asiakasrekisterille

### DIFF
--- a/src/tekniikka.md
+++ b/src/tekniikka.md
@@ -1,0 +1,51 @@
+Tietosuojaseloste - Tekniikkavuokrauksen asiakasrekisteri
+Tämä on EU:n yleisen tietosuoja-asetuksen (GDPR) mukainen rekisteri- ja tietosuojaseloste.
+
+Laatimispäivämäärä: 8.8.2021
+
+1. Rekisterinpitäjä
+Teekkarispeksi ry
+PL69 02151 Espoo
+Y-tunnus: 1888541-7
+
+2. Rekisteristä vastaava yhteyshenkilö
+Teekkarispeksi Ry:n sihteeri hallitus@teekkarispeksi.fi
+
+3. Rekisterin nimi
+Teekkarispeksi ry:n tekniikkavuokrauksen asiakasrekisteri
+
+4. Oikeusperuste ja henkilötietojen käsittelyn tarkoitus
+EU:n yleisen tietosuoja-asetuksen mukainen oikeusperuste henkilötietojen käsittelylle on rekisterinpitäjän oikeutettu etu, sekä arkaluontoisiksi luokiteltavien terveydentilaa koskevien tietojen kohdalla rekisteröidyn suostumus.
+
+Rekisteriin kerättyjä yhteystietoja käytetään vain tekniikkavuokraukseen liittyvään yhteydenpitoon, sekä kalustovuokran laskutukseen.
+
+5. Rekisterin tietosisältö
+Rekisteriin voidaan tallentaa seuraavia tietoja:
+
+Nimi
+Sähköpostiosoite
+Käyttäjätunnus Telegram-viestintäsovelluksessa
+Puhelinnumero
+Laskutusosoite
+Laskutuksen sähköpostiosoite
+
+6. Säännönmukaiset tietolähteet
+Rekisteriin tallennettavat tiedot saadaan rekisteröidyiltä sähköisellä lomakkeella.
+
+7. Tietojen säilytys ja käsittely
+Tiedot säilytetään sähköisessä muodossa pilvipalvelussa. Palvelu toteuttaa asianmukaisen sähköisen suojauksen ja käsittelijät tunnistetaan henkilökohtaisella käyttäjätunnuksella ja salasanalla.
+
+Rekisterin tietoihin on pääsy Teekkarispeksi ry:n hallituksen jäsenillä, tietohallintovastaavalla, sekä tekniikkavuokrauksesta vastaavalla henkilöllä.
+
+8. Rekisterin tietojen säilytysaika
+Rekisterissä säilytetään vain tekniikkavuokrauksen asiakastietoja. Rekisteröidyt tiedot poistetaan viimeistään 6 kuukauden kuluttua kalustovuokraan liittyvien laskujen maksamisesta.
+
+Poikkeustilanteessa rekisteröidyn tietoja voidaan säilyttää pidempään. Tällöin rekisteröidylle ilmoitetaan pidennetystä säilytysajasta ja sen perusteista.
+
+9. Tietojen luovuttaminen ja tietojen siirto EU:n tai ETA:n ulkopuolelle
+Tietoja ei luovuteta kolmansille osapuolille. Tietoja ei luovuteta tai säilytetä EU:n tai Euroopan talousalueen ulkopuolella.
+
+10. Tarkastusoikeus ja oikeus vaatia tiedon korjaamista
+Jokaisella rekisteröidyllä on oikeus tarkastaa rekisteriin tallennetut tietonsa ja vaatia mahdollisen virheellisen tiedon korjaamista tai puutteellisen tiedon täydentämistä.
+
+Tietojen tarkistus- ja oikaisupyynnöt tulee lähettää kirjallisesti rekisterinpitäjälle. Rekisteröidyllä on velvollisuus osoittaa henkilöllisyytensä rekisterinpitäjän niin pyytäessä. Tarkastus- ja oikaisupyynnöt käsitellään 1 kuukauden kuluessa.

--- a/src/tekniikka.md
+++ b/src/tekniikka.md
@@ -9,7 +9,7 @@ PL69 02151 Espoo
 Y-tunnus: 1888541-7
 
 2. Rekisteristä vastaava yhteyshenkilö
-Teekkarispeksi Ry:n sihteeri hallitus@teekkarispeksi.fi
+Teekkarispeksi ry:n sihteeri hallitus@teekkarispeksi.fi
 
 3. Rekisterin nimi
 Teekkarispeksi ry:n tekniikkavuokrauksen asiakasrekisteri


### PR DESCRIPTION
Tekniikkavuokrauksen keikoista ja niiden järjestäjistä kirjan pitämiseksi tarvitaan tekniikkavuokraukselle asiakasrekisteri. Tämä muutos lisää Teekkarispeksin rekistereihin tietosuojaselosteen uutta rekisteriä varten.